### PR TITLE
Pins astlib to 0.11.8

### DIFF
--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -16,9 +16,6 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04 ]
         python-version: ["3.8", "3.9", "3.10"]
-        include:
-          - os: ubuntu-20.04
-            python-version: 3.6
 
     steps:
     - uses: actions/checkout@v2

--- a/.travis/py3.docker
+++ b/.travis/py3.docker
@@ -9,6 +9,11 @@ RUN pip3 install -U pip setuptools wheel
 #######################################
 # Install python 3 meqtrees
 #######################################
+
+WORKDIR /code
+ADD . /code/tigger-lsm
+RUN pip3 install ./tigger-lsm
+
 # add additional Timba dependencies
 RUN docker-apt-install python3-pyqt4 python3-pyqt5
 WORKDIR /src
@@ -41,10 +46,6 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_PYTHON
 RUN make
 RUN make install
 RUN ldconfig
-
-WORKDIR /code
-ADD . /code/tigger-lsm
-RUN pip3 install ./tigger-lsm
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 2
 # basic install tests

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,15 @@ from setuptools import setup, find_packages
 __version__ = "1.7.3"
 
 # PyQt 5 has not been added here are. It needs to be installed via apt-get which is a Tigger v1.6.0 requirement.
-requirements = ['astro_kittens', 'numpy', 'scipy', 'astlib', 'astropy', 'future', 'python-casacore']
+requirements = ['astro_kittens', 
+                'numpy', 
+                'scipy', 
+                'astlib<=0.11.10; python_version >="3.8"', 
+                'astlib<=0.11.8; python_version <"3.8"', 
+                'astropy', 
+                'future', 
+                'python-casacore'
+]
 
 scripts = [
     'Tigger/bin/tigger-convert',


### PR DESCRIPTION
Deals with a test breaking issue induced by Astlib 0.11.10 under setuptools 59.6.0 which affects Python 3.6 support.

The issue breaks existing tests. Until we migrate to test under Python 3.8 and Python 3.10 this should fix the existing tests.